### PR TITLE
Changed the naming conventions and did some clean ups.

### DIFF
--- a/db.c
+++ b/db.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "db.h"
 
-void init_database(Database* db) {
+void init_db(Database* db) {
     db->size = 0;
     db->limit = MAX_SIZE;
 }
@@ -30,7 +30,7 @@ int getsize_db(Database* db) {
     return db->size;
 }
 
-int binary_search(Database* db, unsigned long key) {
+int binary_search_db(Database* db, unsigned long key) {
     int low = 0, high = db->size - 1;
     while (low <= high) {
         int mid = (low + high) / 2;
@@ -45,76 +45,3 @@ int binary_search(Database* db, unsigned long key) {
     return low;
 }
 
-void create(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
-
-    int i;
-
-    if (db->size >= db->limit) {
-        printf("Database is full\n");
-        return;
-    }
-
-    int index = binary_search(db, key);
-
-    if (index < db->size && db->keys[index] == key) {
-        printf("Key already exists\n");
-        return;
-    }
-
-    for (i = db->size; i > index; --i) {
-        db->keys[i] = db->keys[i - 1];
-        db->values[i] = db->values[i - 1];
-        db->value_sizes[i] = db->value_sizes[i - 1];
-    }
-
-    db->keys[index] = key;
-    db->values[index] = (unsigned char*)malloc(value_size);
-    memcpy(db->values[index], value, value_size);
-    db->value_sizes[index] = value_size;
-    db->size++;
-}
-
-const unsigned char* read(Database* db, unsigned long key, size_t* value_size) {
-    int index = binary_search(db, key);
-    if (index < db->size && db->keys[index] == key) {
-        *value_size = db->value_sizes[index];
-        return db->values[index];
-    }
-    return NULL;
-}
-
-void update(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
-    int index = binary_search(db, key);
-    if (index < db->size && db->keys[index] == key) {
-        free(db->values[index]);  /* Free the old value memory */
-        db->values[index] = (unsigned char*)malloc(value_size);
-        memcpy(db->values[index], value, value_size);
-        db->value_sizes[index] = value_size;
-    } else {
-        printf("Key not found\n");
-    }
-}
-
-void delete(Database* db, unsigned long key) {
-    int i;
-    int index = binary_search(db, key);
-    if (index < db->size && db->keys[index] == key) {
-        free(db->values[index]);  /* Free the value memory */
-        for (i = index; i < db->size - 1; ++i) {
-            db->keys[i] = db->keys[i + 1];
-            db->values[i] = db->values[i + 1];
-            db->value_sizes[i] = db->value_sizes[i + 1];
-        }
-        db->size--;
-    } else {
-        printf("Key not found\n");
-    }
-}
-
-const unsigned char* read_by_index(Database* db, int index, size_t* value_size) {
-    if (index >= 0 && index < db->size) {
-        *value_size = db->value_sizes[index];
-        return db->values[index];
-    }
-    return NULL;
-}

--- a/db.h
+++ b/db.h
@@ -21,11 +21,11 @@ typedef struct {
     int limit;
 } Database;
 
-void init_database(Database* db);
+void init_db(Database* db);
 void setlimit_db(Database* db, int limit);
 int getlimit_db(Database* db);
 int getsize_db(Database* db);
-int binary_search(Database* db, unsigned long key);
+int binary_search_db(Database* db, unsigned long key);
 
 #endif 
 

--- a/demo.c
+++ b/demo.c
@@ -10,26 +10,27 @@
 #include "persistence.h"
 #include "record.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 int main() {
     size_t i;
-    Database db;
-    init_database(&db);
+    Database* db = malloc( sizeof(Database) );
+    init_db(db);
     
-    printf("Size before creating item 100: %d\n", getsize_db(&db));
+    printf("Size before creating item 100: %d\n", getsize_db(db));
 
     unsigned char value1[] = {0x01, 0x02, 0x03, 0x04};
-    create(&db, 100, value1, sizeof(value1));
+    create_record(db, 100, value1, sizeof(value1));
     
-    printf("Size after creating item 100: %d\n", getsize_db(&db));
+    printf("Size after creating item 100: %d\n", getsize_db(db));
     
     unsigned char value2[] = {0x11, 0x12, 0x13, 0x14};
-    create(&db, 200, value2, sizeof(value2));
+    create_record(db, 200, value2, sizeof(value2));
     
-    printf("Size after creating item 200: %d\n", getsize_db(&db));
+    printf("Size after creating item 200: %d\n", getsize_db(db));
 
     size_t size;
-    const unsigned char* read_value = read(&db, 100, &size);
+    const unsigned char* read_value = read_record(db, 100, &size);
     if (read_value) {
         printf("Read key 100: ");
         for (i = 0; i < size; i++) {
@@ -39,9 +40,9 @@ int main() {
     }
 
     unsigned char value3[] = {0x21, 0x22, 0x23};
-    update(&db, 100, value3, sizeof(value3));
+    update_record(db, 100, value3, sizeof(value3));
 
-    read_value = read(&db, 100, &size);
+    read_value = read_record(db, 100, &size);
     if (read_value) {
         printf("Read key 100 after update: ");
         for (i = 0; i < size; i++) {
@@ -50,11 +51,11 @@ int main() {
         printf("\n");
     }
 
-    delete(&db, 100);
+    delete_record(db, 100);
 
-    printf("Size after delete: %d\n", getsize_db(&db));
+    printf("Size after delete: %d\n", getsize_db(db));
 
-    const unsigned char* read_index_value = read_by_index(&db, 0, &size);
+    const unsigned char* read_index_value = read_record_by_index(db, 0, &size);
     if (read_index_value) {
         printf("Read by index 0: ");
         for (i = 0; i < size; i++) {
@@ -63,13 +64,13 @@ int main() {
         printf("\n");
     }
 
-    write_db(&db, "database.dat");
+    write_db(db, "database.dat");
 
-    Database db2;
-    init_database(&db2);
-    read_db(&db2, "database.dat");
+    Database* db2 = malloc( sizeof(Database) );
+    init_db(db2);
+    read_db(db2, "database.dat");
 
-    printf("Size of db2 after reading from file: %d\n", getsize_db(&db2));
+    printf("Size of db2 after reading from file: %d\n", getsize_db(db2));
 
     return 0;
 }

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ MANPAGE = libu64.3
 # Source files
 SRCS = db.c record.c persistence.c
 OBJS = $(SRCS:.c=.o)
-CFLAGS = -std=c89 -Wall
+CFLAGS = -std=c89 -Wall -g
 
 # Header files
 HEADERS = db.h record.h persistence.h

--- a/record.c
+++ b/record.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include "db.h"
 
-void create(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
+void create_record(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
 
     int i;
 
@@ -20,7 +20,7 @@ void create(Database* db, unsigned long key, const unsigned char* value, size_t 
         return;
     }
 
-    int index = binary_search(db, key);
+    int index = binary_search_db(db, key);
 
     if (index < db->size && db->keys[index] == key) {
         printf("Key already exists\n");
@@ -40,8 +40,8 @@ void create(Database* db, unsigned long key, const unsigned char* value, size_t 
     db->size++;
 }
 
-const unsigned char* read(Database* db, unsigned long key, size_t* value_size) {
-    int index = binary_search(db, key);
+const unsigned char* read_record(Database* db, unsigned long key, size_t* value_size) {
+    int index = binary_search_db(db, key);
     if (index < db->size && db->keys[index] == key) {
         *value_size = db->value_sizes[index];
         return db->values[index];
@@ -49,8 +49,8 @@ const unsigned char* read(Database* db, unsigned long key, size_t* value_size) {
     return NULL;
 }
 
-void update(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
-    int index = binary_search(db, key);
+void update_record(Database* db, unsigned long key, const unsigned char* value, size_t value_size) {
+    int index = binary_search_db(db, key);
     if (index < db->size && db->keys[index] == key) {
         free(db->values[index]);  /* Free the old value memory */
         db->values[index] = (unsigned char*)malloc(value_size);
@@ -61,9 +61,9 @@ void update(Database* db, unsigned long key, const unsigned char* value, size_t 
     }
 }
 
-void delete(Database* db, unsigned long key) {
+void delete_record(Database* db, unsigned long key) {
     int i;
-    int index = binary_search(db, key);
+    int index = binary_search_db(db, key);
     if (index < db->size && db->keys[index] == key) {
         free(db->values[index]);  /* Free the value memory */
         for (i = index; i < db->size - 1; ++i) {
@@ -77,7 +77,7 @@ void delete(Database* db, unsigned long key) {
     }
 }
 
-const unsigned char* read_by_index(Database* db, int index, size_t* value_size) {
+const unsigned char* read_record_by_index(Database* db, int index, size_t* value_size) {
     if (index >= 0 && index < db->size) {
         *value_size = db->value_sizes[index];
         return db->values[index];

--- a/record.h
+++ b/record.h
@@ -12,11 +12,11 @@
 #include <stddef.h>
 #include "db.h"
 
-void create(Database* db, unsigned long key, const unsigned char* value, size_t value_size);
-const unsigned char* read(Database* db, unsigned long key, size_t* value_size);
-void update(Database* db, unsigned long key, const unsigned char* value, size_t value_size);
-void delete(Database* db, unsigned long key);
-const unsigned char* read_by_index(Database* db, int index, size_t* value_size);
+void create_record(Database* db, unsigned long key, const unsigned char* value, size_t value_size);
+const unsigned char* read_record(Database* db, unsigned long key, size_t* value_size);
+void update_record(Database* db, unsigned long key, const unsigned char* value, size_t value_size);
+void delete_record(Database* db, unsigned long key);
+const unsigned char* read_record_by_index(Database* db, int index, size_t* value_size);
 
 #endif 
 


### PR DESCRIPTION
Changed the naming convention for database method to be suffixed "_db()"
and record methods to be suffixed _"record()" for clarity.

Removed leftover code that was likely forgotten by M.E. in "db.c" while splitting the code into "record" and "database" specific files.

The hard-wired size of the arrays in the database struct (the "MAX_SIZE" in "db.h") makes this code require unlimited stack with static declarations. Changed the database allocation in the "demo.c" driver to be malloc()ed to avoid surprises to whoever tries it.

Added the "-g" switch to the CFLAGS in the makefile to trace lines with Valgrind.
IN 2024/08/03 "INdev"